### PR TITLE
bugfix[#35]: update pt-br short_description.txt

### DIFF
--- a/fastlane/metadata/android/pt-BR/short_description.txt
+++ b/fastlane/metadata/android/pt-BR/short_description.txt
@@ -1,1 +1,1 @@
-Instalador/explorador/editor de APKS e App bundles de código livre para Android!
+Instalador/explorador/editor de APKS e App bundles de código aberto para Android!

--- a/fastlane/metadata/android/pt-BR/short_description.txt
+++ b/fastlane/metadata/android/pt-BR/short_description.txt
@@ -1,1 +1,1 @@
-Instalador/explorador/editor de APKs/Pacote de apps de software livre para o Android!
+Instalador/explorador/editor de APKS e App bundles de código livre para Android!


### PR DESCRIPTION
Updated fastlane-description such as to keep it shorter than 86 characters as mentioned in #35.

This reverse translates to something like:
`Open source APK and App bundles installer/explorer/editor for Android!`

I had to drop the "split apk" part so that it can fit.