### PR TITLE
Load Package Data Asynchronously (MUCH faster loading)

### DIFF
--- a/app/src/main/java/com/apk/editor/activities/InstallerActivity.java
+++ b/app/src/main/java/com/apk/editor/activities/InstallerActivity.java
@@ -114,13 +114,8 @@ public class InstallerActivity extends AppCompatActivity {
         }
         if (sCommonUtils.getString("installationStatus", "waiting", this).equals(getString(R.string.installation_status_success))) {
             Common.getPackageData().add(new PackageItems(
-                    sPackageUtils.getAppName(Common.getPackageName(), this).toString(),
                     Common.getPackageName(),
-                    sAPKUtils.getVersionName(sPackageUtils.getSourceDir(Common.getPackageName(), this), this),
-                    new File(sPackageUtils.getSourceDir(Common.getPackageName(), this)).length(),
-                    Objects.requireNonNull(AppData.getPackageInfo(Common.getPackageName(), this)).firstInstallTime,
-                    Objects.requireNonNull(AppData.getPackageInfo(Common.getPackageName(), this)).lastUpdateTime,
-                    sPackageUtils.getAppIcon(Common.getPackageName(), this)
+                    this
             ));
         }
         if (sFileUtils.exist(new File(getCacheDir(),"splits"))) {

--- a/app/src/main/java/com/apk/editor/adapters/ApplicationsAdapter.java
+++ b/app/src/main/java/com/apk/editor/adapters/ApplicationsAdapter.java
@@ -55,7 +55,7 @@ public class ApplicationsAdapter extends RecyclerView.Adapter<ApplicationsAdapte
     @Override
     public void onBindViewHolder(@NonNull ApplicationsAdapter.ViewHolder holder, int position) {
         try {
-            holder.mAppIcon.setImageDrawable(data.get(position).getAppIcon());
+            data.get(position).loadAppIcon(holder.mAppIcon);
             if (Common.getSearchWord() != null && Common.isTextMatched(data.get(position).getPackageName(), Common.getSearchWord())) {
                 holder.mAppID.setText(APKEditorUtils.fromHtml(data.get(position).getPackageName().replace(Common.getSearchWord(), "<b><i><font color=\"" +
                         Color.RED + "\">" + Common.getSearchWord() + "</font></i></b>")));

--- a/app/src/main/java/com/apk/editor/utils/AppData.java
+++ b/app/src/main/java/com/apk/editor/utils/AppData.java
@@ -35,14 +35,9 @@ public class AppData {
             progressBar.setMax(packages.size());
             try {
                 PackageItems pi = new PackageItems(
-                        sPackageUtils.getAppName(packageInfo.packageName, context).toString(),
                         packageInfo.packageName,
-                        sAPKUtils.getVersionName(sPackageUtils.getSourceDir(packageInfo.packageName, context), context),
-                        new File(sPackageUtils.getSourceDir(packageInfo.packageName, context)).length(),
-                        Objects.requireNonNull(getPackageInfo(packageInfo.packageName, context)).firstInstallTime,
-                        Objects.requireNonNull(getPackageInfo(packageInfo.packageName, context)).lastUpdateTime,
-                        sPackageUtils.getAppIcon(packageInfo.packageName, context)
-                );
+                        context
+                    );
                 // If PackageItems construction survived, then add
                 mData.add(pi);
             } catch (Exception ignored) {

--- a/app/src/main/java/com/apk/editor/utils/recyclerViewItems/PackageItems.java
+++ b/app/src/main/java/com/apk/editor/utils/recyclerViewItems/PackageItems.java
@@ -1,55 +1,70 @@
 package com.apk.editor.utils.recyclerViewItems;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.os.Handler;
+import android.os.Looper;
 
+import androidx.appcompat.widget.AppCompatImageButton;
+
+import com.apk.editor.utils.AppData;
+import com.apk.editor.utils.Common;
+
+import java.io.File;
 import java.io.Serializable;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import in.sunilpaulmathew.sCommon.APKUtils.sAPKUtils;
+import in.sunilpaulmathew.sCommon.PackageUtils.sPackageUtils;
 
 /*
  * Created by APK Explorer & Editor <apkeditor@protonmail.com> on September 05, 2021
  */
 public class PackageItems implements Serializable {
+    private final String mPackageName;
+    private final Context mContext;
+    private Drawable mAppIcon;
 
-    private final Drawable mAppIcon;
-    private final long mAPKSize, mInstalledTime, mUpdatedTime;
-    private final String mAppName, mPackageName, mVersion;
-
-    public PackageItems(String name, String packageName, String version, long apkSize, long installedTime,
-                        long updatedTime, Drawable icon) {
-        this.mAppName = name;
+    public PackageItems(String packageName, Context context) {
         this.mPackageName = packageName;
-        this.mVersion = version;
-        this.mAPKSize = apkSize;
-        this.mInstalledTime = installedTime;
-        this.mUpdatedTime = updatedTime;
-        this.mAppIcon = icon;
+        this.mContext = context;
+    }
+    public String getPackageName() {
+        return mPackageName;
     }
 
     public Drawable getAppIcon() {
         return mAppIcon;
     }
 
-    public long getAPKSize() {
-        return mAPKSize;
-    }
+    public void loadAppIcon(AppCompatImageButton view) {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Handler handler = new Handler(Looper.getMainLooper());
 
+        executor.execute(() -> {
+            mAppIcon = sPackageUtils.getAppIcon(mPackageName, mContext);
+
+            handler.post(() -> {
+                view.setImageDrawable(mAppIcon);
+            });
+        });
+    }
     public long getInstalledTime() {
-        return mInstalledTime;
+        return Objects.requireNonNull(AppData.getPackageInfo(mPackageName, mContext)).firstInstallTime;
     }
-
     public long getUpdatedTime() {
-        return mUpdatedTime;
+        return Objects.requireNonNull(AppData.getPackageInfo(mPackageName, mContext)).lastUpdateTime;
     }
-
     public String getAppName() {
-        return mAppName;
+        return sPackageUtils.getAppName(mPackageName, mContext).toString();
     }
-
-    public String getPackageName() {
-        return mPackageName;
+    public long getAPKSize() {
+        return new File(sPackageUtils.getSourceDir(mPackageName, mContext)).length();
     }
-
     public String getAppVersion() {
-        return mVersion;
+        return sAPKUtils.getVersionName(sPackageUtils.getSourceDir(mPackageName, mContext), mContext);
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0-beta03'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 


### PR DESCRIPTION
**Old Behavior:**
- All data for every installed package would be loading one-by-one at startup

**New Behavior:**
- Only package names are loaded at startup
- App Name, Install Time, Update Time, APK Size, and App Version are loaded only when their getters are called
- App Icons are loaded fully asynchronously using an executor

This pretty much removes the initial loading screen. It now can take up to about a second actual app list to populate, however this takes no more than a few seconds and is much faster than the previous initial load.

I have also bumped the Android Gradle Plugin, as the previous version was incompatible with newer versions of Android Studio.