### PR TITLE
Add an option to disable code decompilation

### DIFF
--- a/app/src/main/java/com/apk/editor/activities/SettingsActivity.java
+++ b/app/src/main/java/com/apk/editor/activities/SettingsActivity.java
@@ -53,6 +53,7 @@ public class SettingsActivity extends AppCompatActivity {
         mData.add(new sSerializableItems(sCommonUtils.getDrawable(R.drawable.ic_theme, this), getString(R.string.app_theme), sThemeUtils.getAppTheme(this), null));
         mData.add(new sSerializableItems(sCommonUtils.getDrawable(R.drawable.ic_translate, this), getString(R.string.language), AppSettings.getLanguage(this), null));
         mData.add(new sSerializableItems(null, getString(R.string.settings_general), null, null));
+        mData.add(new sSerializableItems(sCommonUtils.getDrawable(R.drawable.ic_explore, this), getString(R.string.decompile_setting), AppSettings.getDecompileSettingString(this), null));
         mData.add(new sSerializableItems(sCommonUtils.getDrawable(R.drawable.ic_projects, this), getString(R.string.project_exist_action), AppSettings.getProjectExistAction(this), null));
         mData.add(new sSerializableItems(sCommonUtils.getDrawable(R.drawable.ic_export, this), getString(R.string.export_path_apks), AppSettings.getExportAPKsPath(this), null));
         mData.add(new sSerializableItems(sCommonUtils.getDrawable(R.drawable.ic_export, this), getString(R.string.export_path_resources), AppSettings.getExportPath(this), null));
@@ -72,6 +73,10 @@ public class SettingsActivity extends AppCompatActivity {
                 } else if (position == 2) {
                     AppSettings.setLanguage(this);
                 } else if (position == 4) {
+                    sCommonUtils.saveBoolean("decompileSetting", !AppSettings.getDecompileSetting(this), this);
+                    mData.set(position, new sSerializableItems(sCommonUtils.getDrawable(R.drawable.ic_explore, this), getString(R.string.decompile_setting), AppSettings.getDecompileSettingString(this), null));
+                    mRecycleViewAdapter.notifyItemChanged(position);
+                } else if (position == 5) {
                     new sSingleChoiceDialog(R.drawable.ic_projects, getString(R.string.project_exist_action),
                             AppSettings.getProjectExitingMenu(this), AppSettings.getProjectExitingMenuPosition(this), this) {
 
@@ -92,7 +97,7 @@ public class SettingsActivity extends AppCompatActivity {
                             }
                         }
                     }.show();
-                } else if (position == 5) {
+                } else if (position == 6) {
                     if (Build.VERSION.SDK_INT < 29 && sPermissionUtils.isPermissionDenied(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, this)) {
                         sPermissionUtils.requestPermission(
                                 new String[] {
@@ -124,7 +129,7 @@ public class SettingsActivity extends AppCompatActivity {
                             }.show();
                         }
                     }
-                } else if (position == 6) {
+                } else if (position == 7) {
                     if (Build.VERSION.SDK_INT < 29 && sPermissionUtils.isPermissionDenied(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, this)) {
                         sPermissionUtils.requestPermission(
                                 new String[] {
@@ -160,7 +165,7 @@ public class SettingsActivity extends AppCompatActivity {
                             }.show();
                         }
                     }
-                } else if (APKEditorUtils.isFullVersion(this) && position == 8) {
+                } else if (APKEditorUtils.isFullVersion(this) && position == 9) {
                     new sSingleChoiceDialog(R.drawable.ic_android, getString(R.string.export_options),
                             AppSettings.getExportingAPKMenu(this), AppSettings.getExportingAPKsPosition(this), this) {
 
@@ -187,7 +192,7 @@ public class SettingsActivity extends AppCompatActivity {
                             }
                         }
                     }.show();
-                } else if (APKEditorUtils.isFullVersion(this) && position == 9) {
+                } else if (APKEditorUtils.isFullVersion(this) && position == 10) {
                     new sSingleChoiceDialog(R.drawable.ic_installer, getString(R.string.installer_action),
                             AppSettings.getInstallerMenu(this), AppSettings.getInstallerMenuPosition(this), this) {
 
@@ -214,7 +219,7 @@ public class SettingsActivity extends AppCompatActivity {
                             }
                         }
                     }.show();
-                } else if (APKEditorUtils.isFullVersion(this) && position == 10) {
+                } else if (APKEditorUtils.isFullVersion(this) && position == 11) {
                     new sSingleChoiceDialog(R.drawable.ic_key, getString(R.string.sign_apk_with),
                             new String[] {
                                     getString(R.string.sign_apk_default),

--- a/app/src/main/java/com/apk/editor/adapters/SettingsAdapter.java
+++ b/app/src/main/java/com/apk/editor/adapters/SettingsAdapter.java
@@ -45,6 +45,7 @@ public class SettingsAdapter extends RecyclerView.Adapter<SettingsAdapter.ViewHo
         holder.Title.setText(data.get(position).getTextOne());
         if (data.get(position).getTextTwo() != null) {
             holder.Description.setText(data.get(position).getTextTwo());
+            holder.Description.setVisibility(View.VISIBLE);
         } else {
             holder.Description.setVisibility(View.GONE);
         }
@@ -54,6 +55,7 @@ public class SettingsAdapter extends RecyclerView.Adapter<SettingsAdapter.ViewHo
         holder.mIcon.setColorFilter(sThemeUtils.isDarkTheme(holder.Title.getContext()) ? Color.WHITE : Color.BLACK);
         if (data.get(position).getIcon() != null) {
             holder.mIcon.setImageDrawable(data.get(position).getIcon());
+            holder.Description.setVisibility(View.VISIBLE);
         } else {
             holder.mIcon.setVisibility(View.GONE);
         }

--- a/app/src/main/java/com/apk/editor/utils/AppSettings.java
+++ b/app/src/main/java/com/apk/editor/utils/AppSettings.java
@@ -198,6 +198,14 @@ public class AppSettings {
         }
     }
 
+    public static String getDecompileSettingString(Context context) {
+        return context.getString(getDecompileSetting(context) ?
+                R.string.decompile_on : R.string.decompile_off);
+    }
+    public static Boolean getDecompileSetting(Context context) {
+        return sCommonUtils.getBoolean("decompileSetting", true, context);
+    }
+
     public static String getProjectExistAction(Context context) {
         if (sCommonUtils.getString("projectAction", null, context) != null) {
             return sCommonUtils.getString("projectAction", null, context);

--- a/app/src/main/java/com/apk/editor/utils/tasks/ExploreAPK.java
+++ b/app/src/main/java/com/apk/editor/utils/tasks/ExploreAPK.java
@@ -14,6 +14,7 @@ import com.apk.editor.activities.APKExploreActivity;
 import com.apk.editor.activities.APKTasksActivity;
 import com.apk.editor.utils.APKEditorUtils;
 import com.apk.editor.utils.APKExplorer;
+import com.apk.editor.utils.AppSettings;
 import com.apk.editor.utils.Common;
 import com.apk.editor.utils.DexToSmali;
 
@@ -107,16 +108,18 @@ public class ExploreAPK extends sExecutor {
             }
             APKEditorUtils.unzip(mPackageName != null ? sPackageUtils.getSourceDir(mPackageName, mContext) : mAPKFile.getAbsolutePath(), mExplorePath.getAbsolutePath());
             // Decompile dex file(s)
-            for (File files : Objects.requireNonNull(mExplorePath.listFiles())) {
-                if (files.getName().startsWith("classes") && files.getName().endsWith(".dex") && !Common.isCancelled()) {
-                    sFileUtils.mkdir(mBackUpPath);
-                    sFileUtils.copy(files, new File(mBackUpPath, files.getName()));
-                    sFileUtils.delete(files);
-                    File mDexExtractPath = new File(mExplorePath, files.getName());
-                    sFileUtils.mkdir(mDexExtractPath);
-                    Common.setStatus(mContext.getString(R.string.decompiling, files.getName()));
-                    new DexToSmali(false, mPackageName != null ? new File(sPackageUtils.getSourceDir(mPackageName, mContext))
-                            : mAPKFile, mDexExtractPath, 0, files.getName()).execute();
+            if (AppSettings.getDecompileSetting(mContext)) {
+                for (File files : Objects.requireNonNull(mExplorePath.listFiles())) {
+                    if (files.getName().startsWith("classes") && files.getName().endsWith(".dex") && !Common.isCancelled()) {
+                        sFileUtils.mkdir(mBackUpPath);
+                        sFileUtils.copy(files, new File(mBackUpPath, files.getName()));
+                        sFileUtils.delete(files);
+                        File mDexExtractPath = new File(mExplorePath, files.getName());
+                        sFileUtils.mkdir(mDexExtractPath);
+                        Common.setStatus(mContext.getString(R.string.decompiling, files.getName()));
+                        new DexToSmali(false, mPackageName != null ? new File(sPackageUtils.getSourceDir(mPackageName, mContext))
+                                : mAPKFile, mDexExtractPath, 0, files.getName()).execute();
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="clearing_cache_message">Clearing Cache…</string>
     <string name="copying">Copying \'%s\'…</string>
     <string name="decompiling">Decompiling \'%s\'…</string>
+    <string name="decompile_setting">Code Decompilation</string>
+    <string name="decompile_on">Decompile code to smali</string>
+    <string name="decompile_off">Don\'t decompile code (faster)</string>
     <string name="delete">Delete</string>
     <string name="delete_question">Delete %s?</string>
     <string name="delete_folder">Delete folder</string>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0-beta03'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 


### PR DESCRIPTION
**Old Behavior:**
- Dex-to-smali decompilation is always enabled
- Exploring applications with a lot of code is always slow

**New Behavior:**
- Dex-to-smali decompilation is enabled by default, but may be disabled by the user
- Exploring applications with a lot of code is much faster if decompilation is disabled

Decompilation of dex to smali is a great feature, but accounts for most of the time it takes to open most apk files.

This PR adds an option to the settings which allows you to disable decompilation of dex files. Skipping this works fine, as AEE already uses unmodified dex files for rebuilding if no smali changes were made.

**Caveats:**
- Cached applications will stay with the setting from when the cache was made, leading to the following possiblity:
     1. User disables decompilation
     2. User opens foo.apk
     3. User closes foo.apk, and it is automatically cached
     4. User enables decompilation
     5. User opens foo.apk
     6. foo.apk is loaded from cache and not decompiled
- A few strings have been added, which are only in English

Includes the same AGP update as my other commit.
Includes a fix for a minor issue where "textTwo" and "icon" could be hidden when a setting was changed.